### PR TITLE
Add `-n, --names` option to specify space names to export

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,8 @@ From SwaggerHub Explore, navigate to your browser development tools, locate the 
 
 **Options:**
   > -ec, --explore-cookie <explore-cookie> (REQUIRED)  A valid and active SwaggerHub Explore session cookie
+  > -ep, --export-path <export-path>                   The path to the directory used for exporting data. It can be either relative or absolute
+  > -en, --export-name <export-name>                   The name of the exported file
   > -v, --verbose                                      Include verbose output during processing
   > -?, -h, --help                                     Show help and usage information
 

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ From SwaggerHub Explore, navigate to your browser development tools, locate the 
 
 **Options:**
   > -ec, --explore-cookie <explore-cookie> (REQUIRED)  A valid and active SwaggerHub Explore session cookie
-  > -ep, --export-path <export-path>                   The path to the directory used for exporting data. It can be either relative or absolute
+  > -fp, --file-path <file-path>                       The path to the directory used for exporting data. It can be either relative or absolute
   > -en, --export-name <export-name>                   The name of the exported file
   > -n, --names <names>                                A comma-separated list of space names to export
   > -v, --verbose                                      Include verbose output during processing

--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ From SwaggerHub Explore, navigate to your browser development tools, locate the 
   > -ec, --explore-cookie <explore-cookie> (REQUIRED)  A valid and active SwaggerHub Explore session cookie
   > -ep, --export-path <export-path>                   The path to the directory used for exporting data. It can be either relative or absolute
   > -en, --export-name <export-name>                   The name of the exported file
+  > -n, --names <names>                                A comma-separated list of space names to export
   > -v, --verbose                                      Include verbose output during processing
   > -?, -h, --help                                     Show help and usage information
 

--- a/src/Explore.Cli/Program.cs
+++ b/src/Explore.Cli/Program.cs
@@ -269,37 +269,17 @@ internal class Program
             panel.Width = 100;
             panel.Header = new PanelHeader("SwaggerHub Explore Data").Centered();
 
-            // set the file name if provided
-            string fileName = "ExploreSpaces.json";
-            if (!string.IsNullOrEmpty(exportFileName))
+            // validate the file name if provided
+            if (string.IsNullOrEmpty(exportFileName))
             {
-                // check if the file has a valid extension
-                if (!exportFileName.Contains('.'))
+                // use default if not provided
+                exportFileName = "ExploreSpaces.json";
+            }
+            else
+            {
+                if (!UtilityHelper.IsValidateFileName(ref exportFileName))
                 {
-                    fileName = $"{exportFileName}.json";
-                }
-                else if (exportFileName.EndsWith(".json"))
-                {
-                    fileName = exportFileName;
-                }
-                else
-                {
-                    AnsiConsole.MarkupLine($"[red]The file name provided has an invalid extension. Please review.[/]");
-                    return;
-                }
-
-                // check for invalid characters in the file name
-                if (exportFileName.Contains('\\') || exportFileName.Contains('/'))
-                {
-                    AnsiConsole.MarkupLine($"[red]The file name provided contains invalid characters. Please review.[/]");
-                    return;
-                }
-
-                // check for white space input
-                if (string.IsNullOrWhiteSpace(exportFileName))
-                {
-                    AnsiConsole.MarkupLine($"[red]The file name cannot be empty. Please review.[/]");
-                    return;
+                    return; // file name is invalid, exit
                 }
             }
 
@@ -413,7 +393,7 @@ internal class Program
                 }
 
                 // combine the path and filename
-                filePath = Path.Combine(exportPath, fileName);
+                filePath = Path.Combine(exportPath, exportFileName);
 
                 if (!Directory.Exists(exportPath))
                 {
@@ -436,8 +416,9 @@ internal class Program
             else
             {
                 // if no exportPath is provided, use the current directory
-                filePath = Path.Combine(Environment.CurrentDirectory, fileName);
+                filePath = Path.Combine(Environment.CurrentDirectory, exportFileName);
             }
+
 
             // export the file
             string exploreSpacesJson = JsonSerializer.Serialize(export);

--- a/src/Explore.Cli/Program.cs
+++ b/src/Explore.Cli/Program.cs
@@ -268,6 +268,37 @@ internal class Program
             var panel = new Panel($"You have [green]{spaces!.Embedded!.Spaces!.Count} spaces[/] in explore");
             panel.Width = 100;
             panel.Header = new PanelHeader("SwaggerHub Explore Data").Centered();
+
+            // set the file name if provided
+            string fileName = "ExploreSpaces.json";
+            if (string.IsNullOrWhiteSpace(exportFileName))
+            {
+                AnsiConsole.MarkupLine($"[red]The file name cannot be empty. Please review.[/]");
+                return;
+            }
+
+            // check if the file has a valid extension
+            if (!exportFileName.Contains('.'))
+            {
+                fileName = $"{exportFileName}.json";
+            }
+            else if (exportFileName.EndsWith(".json"))
+            {
+                fileName = exportFileName;
+            }
+            else
+            {
+                AnsiConsole.MarkupLine($"[red]The file name provided has an invalid extension. Please review.[/]");
+                return;
+            }
+
+            // check for invalid characters in the file name
+            if (exportFileName.Contains('\\') || exportFileName.Contains('/'))
+            {
+                AnsiConsole.MarkupLine($"[red]The file name provided contains invalid characters. Please review.[/]");
+                return;
+            }
+            
             AnsiConsole.Write(panel);
             Console.WriteLine(namesList?.Count > 0 ? $"Exporting spaces: {string.Join(", ", namesList)}" : "Exporting all spaces");
             Console.WriteLine("processing...");
@@ -280,6 +311,8 @@ internal class Program
                 {
                     continue;
                 }
+
+
 
                 var resultTable = new Table() { Title = new TableTitle(text: $"PROCESSING [green]{space.Name}[/]"), Width = 100, UseSafeBorder = true };
                 resultTable.AddColumn("Result");
@@ -366,8 +399,7 @@ internal class Program
                 ExploreSpaces = spacesToExport
             };
 
-            // set the file name if provided
-            var fileName = string.IsNullOrEmpty(exportFileName) ? "ExploreSpaces.json" : $"{exportFileName}.json";
+
 
             // set the export path if provided
             string filePath;

--- a/src/Explore.Cli/Program.cs
+++ b/src/Explore.Cli/Program.cs
@@ -239,7 +239,7 @@ internal class Program
         }
     }
 
-    internal static async Task ExportSpaces(string exploreCookie, string exportPath, string exportFileName, string names, bool? verboseOutput)
+    internal static async Task ExportSpaces(string exploreCookie, string filePath, string exportFileName, string names, bool? verboseOutput)
     {
         var httpClient = new HttpClient
         {
@@ -275,13 +275,25 @@ internal class Program
                 // use default if not provided
                 exportFileName = "ExploreSpaces.json";
             }
-            else
+            else if (!UtilityHelper.IsValidFileName(ref exportFileName))
             {
-                if (!UtilityHelper.IsValidateFileName(ref exportFileName))
-                {
-                    return; // file name is invalid, exit
-                }
+                return; // file name is invalid, exit
             }
+
+            // validate the export path if provided
+            // string filePath;
+            if (string.IsNullOrEmpty(filePath))
+            {
+                // use default (current directory) if not provided
+                filePath = Path.Combine(Environment.CurrentDirectory, exportFileName);
+            }
+            else if (!UtilityHelper.IsValidFilePath(ref filePath))
+            {
+                return; // file path is invalid, exit
+            }
+
+            // combine the path and filename
+            filePath = Path.Combine(filePath, exportFileName);
 
             AnsiConsole.Write(panel);
             Console.WriteLine(namesList?.Count > 0 ? $"Exporting spaces: {string.Join(", ", namesList)}" : "Exporting all spaces");
@@ -380,44 +392,6 @@ internal class Program
                 Info = new Info() { ExportedAt = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss.fffZ") },
                 ExploreSpaces = spacesToExport
             };
-
-            // set the export path if provided
-            string filePath;
-            if (!string.IsNullOrEmpty(exportPath))
-            {
-                // check if the exportPath is an absolute path
-                if (!Path.IsPathRooted(exportPath))
-                {
-                    // if not, make it relative to the current directory
-                    exportPath = Path.Combine(Environment.CurrentDirectory, exportPath);
-                }
-
-                // combine the path and filename
-                filePath = Path.Combine(exportPath, exportFileName);
-
-                if (!Directory.Exists(exportPath))
-                {
-                    try
-                    {
-                        Directory.CreateDirectory(exportPath);
-                    }
-                    catch (UnauthorizedAccessException)
-                    {
-                        AnsiConsole.MarkupLine($"[red]Access to {filePath} is denied. Please review file permissions any try again.[/]");
-                        return;
-                    }
-                    catch (Exception ex)
-                    {
-                        AnsiConsole.MarkupLine($"[red]An error occurred accessing the file: {ex.Message}[/]");
-                        return;
-                    }
-                }
-            }
-            else
-            {
-                // if no exportPath is provided, use the current directory
-                filePath = Path.Combine(Environment.CurrentDirectory, exportFileName);
-            }
 
 
             // export the file

--- a/src/Explore.Cli/UtilityHelper.cs
+++ b/src/Explore.Cli/UtilityHelper.cs
@@ -189,12 +189,22 @@ public static class UtilityHelper
 
     public static bool IsValidFileName(ref string fileName)
     {
+        char[] invalidFileNameChars = new char[]
+        {
+            '<', '>', ':', '"', '/', '\\', '|', '?', '*', '\0',
+            // Control characters (0x00-0x1F)
+            '\x01', '\x02', '\x03', '\x04', '\x05', '\x06', '\x07',
+            '\x08', '\x09', '\x0A', '\x0B', '\x0C', '\x0D', '\x0E', '\x0F',
+            '\x10', '\x11', '\x12', '\x13', '\x14', '\x15', '\x16', '\x17',
+            '\x18', '\x19', '\x1A', '\x1B', '\x1C', '\x1D', '\x1E', '\x1F'
+        };
+
         if (fileName == null)
         {
             return false;
         }
 
-        if (fileName.IndexOfAny(Path.GetInvalidFileNameChars()) > 0)
+        if (fileName.IndexOfAny(invalidFileNameChars) > 0)
         {
             AnsiConsole.MarkupLine($"[red]The file name '{fileName}' contains invalid characters. Please review.[/]");
             return false;
@@ -235,15 +245,15 @@ public static class UtilityHelper
             return false;
         }
 
-        // the following characters are not detected by GetInvalidPathChars() but are invalid on Windows as a path
-        var invalidChars = new List<char>(Path.GetInvalidPathChars())
+        char[] invalidChars = new char[]
         {
-            '<',
-            '>',
-            '"',
-            '?',
-            '*',
-        }.ToArray();
+            '<', '>', ':', '"', '|', '?', '*', '\0',
+            // Control characters (0x00-0x1F)
+            '\x01', '\x02', '\x03', '\x04', '\x05', '\x06', '\x07',
+            '\x08', '\x09', '\x0A', '\x0B', '\x0C', '\x0D', '\x0E', '\x0F',
+            '\x10', '\x11', '\x12', '\x13', '\x14', '\x15', '\x16', '\x17',
+            '\x18', '\x19', '\x1A', '\x1B', '\x1C', '\x1D', '\x1E', '\x1F'
+        };
 
         if (filePath.IndexOfAny(invalidChars) > 0)
         {

--- a/test/Explore.Cli.Tests/UtilityHelperTests.cs
+++ b/test/Explore.Cli.Tests/UtilityHelperTests.cs
@@ -57,5 +57,62 @@ public class UtilityHelperTests
         var actual = UtilityHelper.IsContentTypeExpected(message.Content.Headers, "text/html");
 
         Assert.False(actual);
-    }    
+    }
+
+    [Theory]
+    [InlineData(" ")]
+    [InlineData("")]
+    [InlineData(null)]
+    [InlineData("test/")]
+    [InlineData("test\\")]
+    [InlineData("test:")]
+    [InlineData("test*")]
+    [InlineData("test?")]
+    [InlineData("test\"")]
+    [InlineData("test<")]
+    [InlineData("test>")]
+    [InlineData("test|")]
+    [InlineData("test.")]
+    [InlineData("test.txt")]
+    public void IsValidFileName_Should_Fail(string input)
+    {
+        Assert.False(UtilityHelper.IsValidFileName(ref input));
+    }
+
+    [Theory]
+    [InlineData("test", "test.json")]
+    [InlineData("test-test", "test-test.json")]
+    [InlineData("test_test", "test_test.json")]
+    [InlineData("test.json", "test.json")]
+    [InlineData("test.JSON", "test.JSON")]
+    public void IsValidFileName_Should_Pass(string input, string expected)
+    {
+        Assert.True(UtilityHelper.IsValidFileName(ref input));
+        Assert.Equal(input, expected);
+    }
+
+    [Theory]
+    [InlineData(" ")]
+    [InlineData("")]
+    [InlineData(null)]
+    [InlineData("test:")]
+    [InlineData("test*")]
+    [InlineData("test?")]
+    [InlineData("test\"")]
+    [InlineData("test<")]
+    [InlineData("test>")]
+    [InlineData("test|")]
+    public void IsValidFilePath_Should_Fail_With_Invalid_Chars(string input)
+    {
+        Assert.False(UtilityHelper.IsValidFilePath(ref input));
+    }
+
+    [Theory]
+    [InlineData("test")]
+    [InlineData("test/test")]
+    [InlineData("test.test")]
+    public void IsValidFilePath_Should_Pass(string input)
+    {
+        Assert.True(UtilityHelper.IsValidFilePath(ref input));
+    }
 }


### PR DESCRIPTION
I've added a new option: `--names` and added it to the `ExportSpaces` method. 
When provided, it is a comma separated string, but the values are trimmed. So, both `"test1,test2"` and `"test1, test2"` will work. 

Let me know if you need any changes.

closes #4 