### PR TITLE
chore: fix export issue and ReadMe

### DIFF
--- a/.github/gitversion.yml
+++ b/.github/gitversion.yml
@@ -1,4 +1,4 @@
-next-version: 0.3
+next-version: 0.4
 assembly-versioning-scheme: MajorMinorPatch
 assembly-file-versioning-scheme: MajorMinorPatchTag
 assembly-informational-format: '{InformationalVersion}'

--- a/README.md
+++ b/README.md
@@ -78,7 +78,8 @@ From SwaggerHub Explore, navigate to your browser development tools, locate the 
 
 **Command Options**:
 
- ``` _____                  _                              ____   _   _
+```
+  _____                  _                              ____   _   _
  | ____| __  __  _ __   | |   ___    _ __    ___       / ___| | | (_)
  |  _|   \ \/ / | '_ \  | |  / _ \  | '__|  / _ \     | |     | | | |
  | |___   >  <  | |_) | | | | (_) | | |    |  __/  _  | |___  | | | |
@@ -130,12 +131,17 @@ From SwaggerHub Explore, navigate to your browser development tools, locate the 
   > Explore.CLI export-spaces [options]
 
 **Options:**
-  > -ec, --explore-cookie <explore-cookie> (REQUIRED)  A valid and active SwaggerHub Explore session cookie
-  > -fp, --file-path <file-path>                       The path to the directory used for exporting data. It can be either relative or absolute
-  > -en, --export-name <export-name>                   The name of the exported file
-  > -n, --names <names>                                A comma-separated list of space names to export
-  > -v, --verbose                                      Include verbose output during processing
-  > -?, -h, --help                                     Show help and usage information
+  > `-ec`, `--explore-cookie` <explore-cookie> (REQUIRED)  A valid and active SwaggerHub Explore session cookie
+
+  > `-fp`, `--file-path` <file-path>                       The path to the directory used for exporting data. It can be either relative or absolute
+
+  > `-en`, `--export-name` <export-name>                   The name of the exported file
+
+  > `-n`, `--names` <names>                                A comma-separated list of space names to export
+
+  > `-v`, `--verbose`                                      Include verbose output during processing
+
+  > `-?`, `-h`, `--help`                                     Show help and usage information
 
 **Note** - the format for SwaggerHub Explore cookies is as follows: `"cookie-name=cookie-value; cookie-name=cookie-value"`
 
@@ -161,10 +167,13 @@ From SwaggerHub Explore, navigate to your browser development tools, locate the 
   > Explore.CLI import-spaces [options]
 
 **Options:**
-  > -ec, --explore-cookie <explore-cookie> (REQUIRED)  A valid and active SwaggerHub Explore session cookie
-  > -fp, --file-path <file-path> (REQUIRED)            The path to the file used for importing data
-  > -v, --verbose                                      Include verbose output during processing
-  > -?, -h, --help                                     Show help and usage information
+  > `-ec`, `--explore-cookie` <explore-cookie> (REQUIRED)  A valid and active SwaggerHub Explore session cookie
+
+  > `-fp`, `--file-path` <file-path> (REQUIRED)            The path to the file used for importing data
+
+  > `-v`, `--verbose`                                      Include verbose output during processing
+
+  > `-?`, `-h`, `--help`                                     Show help and usage information
 
 **Note** - the format for SwaggerHub Explore cookies is as follows: `"cookie-name=cookie-value; cookie-name=cookie-value"`
 

--- a/src/Explore.Cli/Program.cs
+++ b/src/Explore.Cli/Program.cs
@@ -285,7 +285,7 @@ internal class Program
             if (string.IsNullOrEmpty(filePath))
             {
                 // use default (current directory) if not provided
-                filePath = Path.Combine(Environment.CurrentDirectory, exportFileName);
+                filePath = Environment.CurrentDirectory;
             }
             else if (!UtilityHelper.IsValidFilePath(ref filePath))
             {

--- a/src/Explore.Cli/UtilityHelper.cs
+++ b/src/Explore.Cli/UtilityHelper.cs
@@ -189,22 +189,12 @@ public static class UtilityHelper
 
     public static bool IsValidFileName(ref string fileName)
     {
-        char[] invalidFileNameChars = new char[]
-        {
-            '<', '>', ':', '"', '/', '\\', '|', '?', '*', '\0',
-            // Control characters (0x00-0x1F)
-            '\x01', '\x02', '\x03', '\x04', '\x05', '\x06', '\x07',
-            '\x08', '\x09', '\x0A', '\x0B', '\x0C', '\x0D', '\x0E', '\x0F',
-            '\x10', '\x11', '\x12', '\x13', '\x14', '\x15', '\x16', '\x17',
-            '\x18', '\x19', '\x1A', '\x1B', '\x1C', '\x1D', '\x1E', '\x1F'
-        };
-
         if (fileName == null)
         {
             return false;
         }
 
-        if (fileName.IndexOfAny(invalidFileNameChars) > 0)
+        if (fileName.IndexOfAny(Path.GetInvalidFileNameChars()) > 0)
         {
             AnsiConsole.MarkupLine($"[red]The file name '{fileName}' contains invalid characters. Please review.[/]");
             return false;
@@ -245,17 +235,7 @@ public static class UtilityHelper
             return false;
         }
 
-        char[] invalidChars = new char[]
-        {
-            '<', '>', ':', '"', '|', '?', '*', '\0',
-            // Control characters (0x00-0x1F)
-            '\x01', '\x02', '\x03', '\x04', '\x05', '\x06', '\x07',
-            '\x08', '\x09', '\x0A', '\x0B', '\x0C', '\x0D', '\x0E', '\x0F',
-            '\x10', '\x11', '\x12', '\x13', '\x14', '\x15', '\x16', '\x17',
-            '\x18', '\x19', '\x1A', '\x1B', '\x1C', '\x1D', '\x1E', '\x1F'
-        };
-
-        if (filePath.IndexOfAny(invalidChars) > 0)
+        if (filePath.IndexOfAny(Path.GetInvalidPathChars()) > 0)
         {
             AnsiConsole.MarkupLine($"[red]The file path '{filePath}' contains invalid characters. Please review.[/]");
             return false;

--- a/test/Explore.Cli.Tests/UtilityHelperTests.cs
+++ b/test/Explore.Cli.Tests/UtilityHelperTests.cs
@@ -110,6 +110,7 @@ public class UtilityHelperTests
     [Theory]
     [InlineData("test")]
     [InlineData("test/test")]
+    [InlineData("test\\test")]
     [InlineData("test.test")]
     public void IsValidFilePath_Should_Pass(string input)
     {

--- a/test/Explore.Cli.Tests/UtilityHelperTests.cs
+++ b/test/Explore.Cli.Tests/UtilityHelperTests.cs
@@ -64,14 +64,6 @@ public class UtilityHelperTests
     [InlineData("")]
     [InlineData(null)]
     [InlineData("test/")]
-    [InlineData("test\\")]
-    [InlineData("test:")]
-    [InlineData("test*")]
-    [InlineData("test?")]
-    [InlineData("test\"")]
-    [InlineData("test<")]
-    [InlineData("test>")]
-    [InlineData("test|")]
     [InlineData("test.")]
     [InlineData("test.txt")]
     public void IsValidFileName_Should_Fail(string input)
@@ -95,13 +87,6 @@ public class UtilityHelperTests
     [InlineData(" ")]
     [InlineData("")]
     [InlineData(null)]
-    [InlineData("test:")]
-    [InlineData("test*")]
-    [InlineData("test?")]
-    [InlineData("test\"")]
-    [InlineData("test<")]
-    [InlineData("test>")]
-    [InlineData("test|")]
     public void IsValidFilePath_Should_Fail_With_Invalid_Chars(string input)
     {
         Assert.False(UtilityHelper.IsValidFilePath(ref input));


### PR DESCRIPTION
fixes: #11, #6

Additionally, addresses export issues introduced as part of https://github.com/SmartBear-DevRel/explore-cli/pull/14

Manually validation via:
- check out PR branch
- `cd ./src/Explore.Cli`
- `dotnet build`
- `dotnet test ../../test/Explore.Cli.Tests/Explore.Cli.Tests.csproj`
- `dotnet pack`
- `dotnet tool uninstall --global explore.cli`
-`dotnet tool install --global --add-source ./nupkg Explore.Cli`