### PR TITLE
Extend `--names` support for the import option

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,6 @@ Simple utility CLI for importing data into SwaggerHub Explore.
 >  `-?`, `-h`, `--help`  Show help and usage information
 
 **Commands:**
->  `import-inspector-collections`  Import Swagger Inspector collections into SwaggerHub Explore
->
 >  `export-spaces`                 Export SwaggerHub Explore spaces to filesystem
 >
 >  `import-spaces`                 Import SwaggerHub Explore spaces from a file
@@ -33,7 +31,6 @@ Simple utility CLI for importing data into SwaggerHub Explore.
 You will need the following:
 - .NET 7.0 (or above). Follow instructions for [Windows](https://learn.microsoft.com/en-us/dotnet/core/install/windows?tabs=net70), [Linux](https://learn.microsoft.com/en-us/dotnet/core/install/linux), or [MacOS](https://learn.microsoft.com/en-us/dotnet/core/install/macos).
 - A SwaggerHub Explore account, register at https://try.smartbear.com/swaggerhub-explore (if required).
-- If you want to import data from the legacy Swagger Inspector tool, the you'll also need a Swagger Inspector account, register by clicking the `Sign Up` button at https://inspector.swagger.io/builder (if required).
 
 ### Install the CLI
 
@@ -43,9 +40,7 @@ Download and install the CLI tool from Nuget: https://www.nuget.org/packages/Exp
 
 ### Session Cookies for CLI command
 
-You will need to obtain certain cookies from an active session in SwaggerHub Explore to invoke the `CLI` commands. For the `import-inspector-collections` CLI command, you will also need to obtain a cookie from an active Swagger Inspector session.
-
-From Swagger Inspector, navigate to your browser development tools, locate the application cookies and extract the `inspector-token` cookie.
+You will need to obtain certain cookies from an active session in SwaggerHub Explore to invoke the `CLI` commands.
 
 From SwaggerHub Explore, navigate to your browser development tools, locate the application cookies and extract the `SESSION` and `XSRF-TOKEN` cookies.
 
@@ -73,45 +68,6 @@ From SwaggerHub Explore, navigate to your browser development tools, locate the 
 
 **Safari**
 > Develop `>` Show Web Inspector. If you can't see the Develop menu, go to Safari `>` Preferences `>` Advanced, and check the Show Develop menu in menu bar checkbox.
-
-### Running the `import-inspector-collections` command
-
-**Command Options**:
-
-```
-  _____                  _                              ____   _   _
- | ____| __  __  _ __   | |   ___    _ __    ___       / ___| | | (_)
- |  _|   \ \/ / | '_ \  | |  / _ \  | '__|  / _ \     | |     | | | |
- | |___   >  <  | |_) | | | | (_) | | |    |  __/  _  | |___  | | | |
- |_____| /_/\_\ | .__/  |_|  \___/  |_|     \___| (_)  \____| |_| |_|
-                |_|
-```
-
-**Description:**
-  > Import Swagger Inspector collections into SwaggerHub Explore
-
-**Usage:**
-  > `Explore.CLI import-inspector-collections [options]`
-
-**Options:**
-
-
-  > `-u`, `--username` <username> (REQUIRED)                   Username from Swagger Inspector.
-  
-  > `-ic`, `--inspector-cookie` <inspector-cookie> (REQUIRED)  A valid and active Swagger Inspector session cookie associated with provided username
-  
-  > `-ec`, `--explore-cookie` <explore-cookie> (REQUIRED)      A valid and active SwaggerHub Explore session cookie
-  
-  > `-?`, `-h`, `--help`                                         Show help and usage information
-
-
-**Note** - the format for inspector cookie is as follows: `"cookie-name=cookie-value"`
-
-> Example `"inspector-token=34c5921e-fdf8-4531-8d7a-ed2940076444"`
-
-**Note** - the format for SwaggerHub Explore cookies is as follows: `"cookie-name=cookie-value; cookie-name=cookie-value"`
-
->Example: `"SESSION=5a0a2e2f-97c6-4405-b72a-299fa8ce07c8; XSRF-TOKEN=3310cb20-2ec1-4655-b1e3-4ab76a2ac2c8"`
 
 ### Running the `export-spaces` command
 
@@ -170,6 +126,8 @@ From SwaggerHub Explore, navigate to your browser development tools, locate the 
   > `-ec`, `--explore-cookie` <explore-cookie> (REQUIRED)  A valid and active SwaggerHub Explore session cookie
 
   > `-fp`, `--file-path` <file-path> (REQUIRED)            The path to the file used for importing data
+
+  > `-n`, `--names` <names>                                A comma-separated list of space names to import
 
   > `-v`, `--verbose`                                      Include verbose output during processing
 

--- a/src/Explore.Cli/Program.cs
+++ b/src/Explore.Cli/Program.cs
@@ -305,6 +305,7 @@ internal class Program
             {
                 if (namesList?.Count > 0 && space.Name != null && !namesList.Contains(space.Name))
                 {
+                    AnsiConsole.MarkupLine($"[orange3]'Skipped {space.Name}': Name not found in list of names to export[/]");
                     continue;
                 }
 
@@ -384,6 +385,12 @@ internal class Program
                 {
                     AnsiConsole.Write(resultTable);
                 }
+            }
+
+            if (spacesToExport.Count == 0)
+            {
+                AnsiConsole.MarkupLine($"[orange3]No spaces matched the name[/]");
+                return;
             }
 
             // construct the export object

--- a/src/Explore.Cli/Program.cs
+++ b/src/Explore.Cli/Program.cs
@@ -26,7 +26,7 @@ internal class Program
         var exportFileName = new Option<string>(name: "--export-name", description: "The name of the file to export") { IsRequired = false };
         exportFileName.AddAlias("-en");
 
-        var names = new Option<string>(name: "--names", description: "The names of the spaces to export or export") { IsRequired = false };
+        var names = new Option<string>(name: "--names", description: "The names of the spaces to export or import") { IsRequired = false };
         names.AddAlias("-n");
 
         var verbose = new Option<bool?>(name: "--verbose", description: "Include verbose output during processing") { IsRequired = false };

--- a/src/Explore.Cli/Program.cs
+++ b/src/Explore.Cli/Program.cs
@@ -14,12 +14,6 @@ internal class Program
         rootCommand.Name = "Explore.CLI";
         rootCommand.Description = "Simple utility CLI for importing data into and out of SwaggerHub Explore";
 
-        var username = new Option<string>(name: "--username", description: "Username from Swagger Inspector.") { IsRequired = true };
-        username.AddAlias("-u");
-
-        var inspectorCookie = new Option<string>(name: "--inspector-cookie", description: "A valid and active Swagger Inspector session cookie associated with provided username") { IsRequired = true };
-        inspectorCookie.AddAlias("-ic");
-
         var exploreCookie = new Option<string>(name: "--explore-cookie", description: "A valid and active SwaggerHub Explore session cookie") { IsRequired = true };
         exploreCookie.AddAlias("-ec");
 
@@ -38,21 +32,6 @@ internal class Program
         var verbose = new Option<bool?>(name: "--verbose", description: "Include verbose output during processing") { IsRequired = false };
         verbose.AddAlias("-v");
 
-        var importInspectorCollectionsCommand = new Command("import-inspector-collections")
-        {
-            username,
-            inspectorCookie,
-            exploreCookie
-        };
-
-        importInspectorCollectionsCommand.Description = "Import Swagger Inspector collections into SwaggerHub Explore";
-        rootCommand.Add(importInspectorCollectionsCommand);
-
-        importInspectorCollectionsCommand.SetHandler(async (u, ic, ec) =>
-        {
-            await ImportFromInspector(u, ic, ec);
-        }, username, inspectorCookie, exploreCookie);
-
         var exportSpacesCommand = new Command("export-spaces") { exploreCookie, exportFilePath, exportFileName, names, verbose };
         exportSpacesCommand.Description = "Export SwaggerHub Explore spaces to filesystem";
         rootCommand.Add(exportSpacesCommand);
@@ -70,172 +49,6 @@ internal class Program
         AnsiConsole.Write(new FigletText("Explore.Cli").Color(new Color(133, 234, 45)));
 
         return await rootCommand.InvokeAsync(args);
-    }
-
-    internal static async Task ImportFromInspector(string inspectorUsername, string inspectorCookie, string exploreCookie)
-    {
-
-        var httpClient = new HttpClient
-        {
-            BaseAddress = new Uri("https://inspector-api-proxy.swagger.io")
-        };
-
-        var exploreHttpClient = new HttpClient
-        {
-            BaseAddress = new Uri("https://api.explore.swaggerhub.com")
-        };
-
-
-        httpClient.DefaultRequestHeaders.Add("Cookie", inspectorCookie);
-        var inspectorCollectionsResponse = await httpClient.GetAsync($"/repository/v1/{inspectorUsername}/collections");
-
-        if (inspectorCollectionsResponse.StatusCode == HttpStatusCode.Unauthorized)
-        {
-            AnsiConsole.MarkupLine("[red]Could not authenticate with provided inspector cookie[/]");
-            return;
-        }
-
-        if (inspectorCollectionsResponse.StatusCode == HttpStatusCode.OK)
-        {
-            var collections = await inspectorCollectionsResponse.Content.ReadFromJsonAsync<List<InspectorCollection>>();
-            var panel = new Panel($"You have [green]{collections!.Count} collections[/] in inspector");
-            panel.Width = 100;
-            panel.Header = new PanelHeader("Swagger Inspector Data").Centered();
-            AnsiConsole.Write(panel);
-            Console.WriteLine("");
-
-
-            var counter = 0;
-            foreach (var collection in collections)
-            {
-
-
-                if (MappingHelper.CollectionEntriesNotLimitedToSoap(collection.CollectionEntries))
-                {
-
-                    var resultTable = new Table() { Title = new TableTitle(text: $"IMPORTING [green]{collection.Name}[/] TO EXPLORE"), Width = 100, UseSafeBorder = true };
-                    resultTable.AddColumn("Result");
-                    resultTable.AddColumn(new TableColumn("Details").Centered());
-
-                    //prepare request body
-                    var cleanedCollectionName = UtilityHelper.CleanString(collection.Name);
-                    var spaceContent = new StringContent(JsonSerializer.Serialize(new SpaceRequest() { Name = cleanedCollectionName }), Encoding.UTF8, "application/json");
-
-                    exploreHttpClient.DefaultRequestHeaders.Clear();
-                    exploreHttpClient.DefaultRequestHeaders.Add("Cookie", exploreCookie);
-                    exploreHttpClient.DefaultRequestHeaders.Add("X-Xsrf-Token", $"{MappingHelper.ExtractXSRFTokenFromCookie(exploreCookie)}");
-                    var spacesResponse = await exploreHttpClient.PostAsync("/spaces-api/v1/spaces", spaceContent);
-                    //Console.WriteLine(JsonSerializer.Serialize(new SpaceRequest() { Name = collection.Name }));
-
-                    if (spacesResponse.StatusCode == HttpStatusCode.Created)
-                    {
-                        var apiImportResults = new Table() { Title = new TableTitle(text: $"SPACE [green]{cleanedCollectionName}[/] CREATED"), Width = 75, UseSafeBorder = true };
-                        apiImportResults.AddColumn("Result");
-                        apiImportResults.AddColumn("API Imported");
-                        apiImportResults.AddColumn("Connection Imported");
-
-                        //grab the space id
-                        var spaceResponse = spacesResponse.Content.ReadFromJsonAsync<SpaceResponse>();
-
-                        if (collection.CollectionEntries != null)
-                        {
-                            foreach (var entry in collection.CollectionEntries)
-                            {
-                                //now let's create an API entry in the space
-                                var cleanedAPIName = UtilityHelper.CleanString(entry.Name);
-                                var apiContent = new StringContent(JsonSerializer.Serialize(new ApiRequest() { Name = cleanedAPIName, Type = "REST", Description = $"imported from inspector on {DateTime.UtcNow.ToShortDateString()}" }), Encoding.UTF8, "application/json");
-
-                                exploreHttpClient.DefaultRequestHeaders.Clear();
-                                exploreHttpClient.DefaultRequestHeaders.Add("Cookie", exploreCookie);
-                                exploreHttpClient.DefaultRequestHeaders.Add("X-Xsrf-Token", $"{MappingHelper.ExtractXSRFTokenFromCookie(exploreCookie)}");
-                                var apiResponse = await exploreHttpClient.PostAsync($"/spaces-api/v1/spaces/{spaceResponse.Result?.Id}/apis", apiContent);
-
-                                if (apiResponse.StatusCode == HttpStatusCode.Created)
-                                {
-
-                                    var createdApiResponse = apiResponse.Content.ReadFromJsonAsync<ApiResponse>();
-                                    var connectionRequestBody = JsonSerializer.Serialize(MappingHelper.MapInspectorCollectionEntryToExploreConnection(entry));
-                                    var connectionContent = new StringContent(connectionRequestBody, Encoding.UTF8, "application/json");
-
-                                    //now let's do the work and import the connection
-                                    exploreHttpClient.DefaultRequestHeaders.Clear();
-                                    exploreHttpClient.DefaultRequestHeaders.Add("Cookie", exploreCookie);
-                                    exploreHttpClient.DefaultRequestHeaders.Add("X-Xsrf-Token", $"{MappingHelper.ExtractXSRFTokenFromCookie(exploreCookie)}");
-                                    var connectionResponse = await exploreHttpClient.PostAsync($"/spaces-api/v1/spaces/{spaceResponse.Result?.Id}/apis/{createdApiResponse.Result?.Id}/connections", connectionContent);
-
-                                    if (connectionResponse.StatusCode == HttpStatusCode.Created)
-                                    {
-                                        apiImportResults.AddRow("[green]OK[/]", $"API '{cleanedAPIName}' created", "Connection created");
-                                    }
-                                    else
-                                    {
-                                        apiImportResults.AddRow("[orange3]OK[/]", $"API '{cleanedAPIName}' created", "[orange3]Connection NOT created[/]");
-                                    }
-                                }
-                                else
-                                {
-                                    apiImportResults.AddRow("[red]NOK[/]", $"API creation failed. StatusCode {apiResponse.StatusCode}", "");
-                                }
-                            }
-
-                            resultTable.AddRow(new Markup("[green]success[/]"), apiImportResults);
-                        }
-
-                        AnsiConsole.Write(resultTable);
-                        Console.WriteLine("");
-                    }
-                    else
-                    {
-                        switch (spacesResponse.StatusCode)
-                        {
-                            case HttpStatusCode.OK:
-                                // not expecting a 200 OK here - this would be returned for a failed auth and a redirect to SB ID
-                                resultTable.AddRow(new Markup("[red]failure[/]"), new Markup($"[red] Auth failed connecting to SwaggerHub Explore. Please review provided cookie.[/]"));
-                                AnsiConsole.Write(resultTable);
-                                Console.WriteLine("");
-                                break;
-
-                            case HttpStatusCode.Conflict:
-                                var apiImportResults = new Table() { Title = new TableTitle(text: $"[orange3]SPACE[/] {cleanedCollectionName} [orange3]ALREADY EXISTS[/]") };
-                                apiImportResults.AddColumn("Result");
-                                apiImportResults.AddColumn("API Imported");
-                                apiImportResults.AddColumn("Connection Imported");
-                                apiImportResults.AddRow("skipped", "", "");
-
-                                resultTable.AddRow(new Markup("[orange3]skipped[/]"), apiImportResults);
-                                AnsiConsole.Write(resultTable);
-                                Console.WriteLine("");
-                                break;
-
-                            default:
-                                resultTable.AddRow(new Markup("[red]failure[/]"), new Markup($"[red] StatusCode: {spacesResponse.StatusCode}, Details: {spacesResponse.ReasonPhrase}[/]"));
-                                AnsiConsole.Write(resultTable);
-                                Console.WriteLine("");
-                                break;
-                        }
-                    }
-                }
-                else
-                {
-                    var resultTable = new Table() { Title = new TableTitle(text: $"IMPORTING [green]{collection.Name}[/] TO EXPLORE"), Width = 100, UseSafeBorder = true };
-                    resultTable.AddColumn("Result");
-                    resultTable.AddColumn(new TableColumn("Details").Centered());
-                    resultTable.AddRow(new Markup("[orange3]skipped[/]"), new Markup("[orange3]No transactions to import[/]"));
-                    AnsiConsole.Write(resultTable);
-                    Console.WriteLine("");
-                }
-
-                counter++;
-                Thread.Sleep(200);
-            }
-
-            Console.WriteLine("");
-            AnsiConsole.MarkupLine("[green] All done! We're finished importing collections[/]");
-        }
-        else
-        {
-            AnsiConsole.MarkupLine($"[red]StatusCode {inspectorCollectionsResponse.StatusCode} returned from the Inspector API[/]");
-        }
     }
 
     internal static async Task ExportSpaces(string exploreCookie, string filePath, string exportFileName, string names, bool? verboseOutput)
@@ -388,7 +201,7 @@ internal class Program
 
             if (spacesToExport.Count == 0)
             {
-                AnsiConsole.MarkupLine($"[orange3]No spaces matched the name[/]");
+                AnsiConsole.MarkupLine($"[orange3]No spaces matched the provided names[/]");
                 return;
             }
 
@@ -398,7 +211,6 @@ internal class Program
                 Info = new Info() { ExportedAt = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss.fffZ") },
                 ExploreSpaces = spacesToExport
             };
-
 
             // export the file
             string exploreSpacesJson = JsonSerializer.Serialize(export);
@@ -497,7 +309,6 @@ internal class Program
                     resultTable.AddColumn("Result");
                     resultTable.AddColumn(new TableColumn("Details").Centered());
 
-
                     var importedSpace = await UpsertSpace(exploreCookie, spaceExists, exportedSpace.Name, exportedSpace.Id.ToString());
 
                     if (!string.IsNullOrEmpty(importedSpace.Name))
@@ -533,7 +344,6 @@ internal class Program
                                                 }
                                             }
                                         }
-
                                     }
                                 }
                                 apiImportResults.AddRow("[orange3]skipped[/]", $"API '{exportedAPI.Name}' skipped", $"Kafka not yet supported by export");
@@ -552,7 +362,6 @@ internal class Program
                     {
                         AnsiConsole.Write(resultTable);
                     }
-
                 }
             }
 
@@ -570,10 +379,8 @@ internal class Program
         }
     }
 
-
     private static async Task<bool> CheckSpaceExists(string exploreCookie, string? id, bool? verboseOutput)
     {
-
         if (string.IsNullOrEmpty(id))
         {
             return false;
@@ -600,7 +407,6 @@ internal class Program
             return true;
         }
 
-
         if (verboseOutput != null && verboseOutput == true)
         {
             AnsiConsole.MarkupLine($"[orange3]StatusCode {spacesResponse.StatusCode} returned from the GetSpaceById API. New space will be created[/]");
@@ -611,7 +417,6 @@ internal class Program
 
     private static async Task<bool> CheckApiExists(string exploreCookie, string spaceId, string? id, bool? verboseOutput)
     {
-
         if (string.IsNullOrEmpty(id))
         {
             return false;
@@ -642,7 +447,6 @@ internal class Program
 
     private static async Task<bool> CheckConnectionExists(string exploreCookie, string spaceId, string apiId, string? id, bool? verboseOutput)
     {
-
         if (string.IsNullOrEmpty(id))
         {
             return false;
@@ -670,7 +474,6 @@ internal class Program
 
         return false;
     }
-
 
     private static async Task<SpaceResponse> UpsertSpace(string exploreCookie, bool spaceExists, string? name, string? id)
     {
@@ -704,7 +507,6 @@ internal class Program
                 // swallow 409 as server is being overly strict
                 return new SpaceResponse() { Id = Guid.Parse(id), Name = name };
             }
-
         }
 
         if (spacesResponse.IsSuccessStatusCode)
@@ -723,8 +525,6 @@ internal class Program
 
         return new SpaceResponse();
     }
-
-
 
     private static async Task<ApiResponse> UpsertApi(string exploreCookie, bool spaceExists, string spaceId, string? id, string? name, string? type, bool? verboseOutput)
     {
@@ -790,7 +590,6 @@ internal class Program
         httpClient.DefaultRequestHeaders.Add("Cookie", exploreCookie);
         httpClient.DefaultRequestHeaders.Add("X-Xsrf-Token", $"{MappingHelper.ExtractXSRFTokenFromCookie(exploreCookie)}");
 
-
         var connectionContent = new StringContent(JsonSerializer.Serialize(MappingHelper.MassageConnectionExportForImport(connection)), Encoding.UTF8, "application/json");
 
         HttpResponseMessage? connectionResponse;
@@ -821,18 +620,7 @@ internal class Program
                 var message = await connectionResponse.Content.ReadAsStringAsync();
                 AnsiConsole.WriteLine($"error: {message}");
             }
-
         }
-
         return false;
     }
 }
-
-
-
-
-
-
-
-
-


### PR DESCRIPTION
Addresses #18 

- added a "skipped..." message for the user when the provided names don't match any Spaces
- updated the final import message to reflect whether or not any spaces were imported:
> "0 of x spaces imported..." --> "No spaces matched..."
- added `--names` support for `ImportSpaces`
- removed the `import-inspector-collections` method and all related components
- updated the `README.md` to reflect the above changes

let me know if I've missed anything.