### PR TITLE
feat: Dotnet non-dependant executables

### DIFF
--- a/.github/workflows/build-test-cross.yml
+++ b/.github/workflows/build-test-cross.yml
@@ -1,0 +1,134 @@
+name: cross compile dotnet app
+on:
+  # release:
+  #   types:
+  #     - published
+  workflow_dispatch:
+  push:
+    branches:
+      - "main"
+  pull_request:
+    branches:
+      - "**"
+
+jobs:
+    build:
+      runs-on: ubuntu-latest
+      steps:
+      - name: checkout
+        uses: actions/checkout@v4
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 7.x
+      - name: build dotnet executables
+        run: make build
+      - name: size of executables
+        run: make size
+      - name: file info
+        run: make file
+      - name: prep for distribution
+        run: make dist
+      - uses: actions/upload-artifact@v4
+        with:
+          path: dist/*
+
+    test:
+      defaults:
+        run:
+          shell: sh
+      needs: [build]
+      name: Test ${{ matrix.docker == true && matrix.alpine == true && 'linux-musl' || matrix.docker == true && matrix.alpine == false && 'linux' || matrix.os }}-${{ matrix.arch }}
+      strategy:
+        fail-fast: false
+        matrix:
+          os: [
+            "macos-14",
+            "windows-latest",
+            "ubuntu-latest"
+          ]
+          arch: ["amd64"]
+          alpine: [false]
+          include:
+            - os: "macos-14"
+              arch: "arm64"
+            - os: "ubuntu-latest"
+              arch: "arm64"
+              alpine: true
+              docker: true
+            - os: "ubuntu-latest"
+              arch: "amd64"
+              alpine: true
+              docker: true
+            - os: "ubuntu-latest"
+              arch: "arm64"
+              debian: true
+              docker: true
+      runs-on: ${{ matrix.os }}
+      steps:
+      - name: Download all workflow run artifacts
+        uses: actions/download-artifact@v4
+      - name: list and unpack artifacts
+        run: |
+          ls artifact/*
+          cd artifact && gunzip *.gz && cd ..
+          ls artifact/*
+      - name: Set up QEMU
+        if: matrix.arch == 'arm64' && matrix.docker == true
+        uses: docker/setup-qemu-action@v3
+      - name: test alpine ${{ matrix.arch }} package
+        if: ${{ matrix.alpine == true && matrix.arch == 'arm64' }}
+        run: docker run --platform=linux/${{ matrix.arch }} --rm -v $(pwd):/app alpine /bin/sh -c 'apk add --no-cache gcc icu && chmod +x ./app/artifact/explore-cli-linux-musl-arm64 && ./app/artifact/explore-cli-linux-musl-arm64 --version'
+      - name: test alpine ${{ matrix.arch }} package
+        if: ${{ matrix.alpine == true && matrix.arch == 'amd64' }}
+        run: docker run --platform=linux/${{ matrix.arch }} --rm -v $(pwd):/app alpine /bin/sh -c 'apk add --no-cache gcc icu && chmod +x ./app/artifact/explore-cli-linux-musl-x64 && ./app/artifact/explore-cli-linux-musl-x64 --version'
+      - name: test debian ${{ matrix.arch }} package
+        if: ${{ matrix.debian == true && matrix.arch == 'arm64' }}
+        run: docker run --platform=linux/${{ matrix.arch }} --rm -v $(pwd):/app debian /bin/bash -c 'apt update && apt install -y libicu-dev && chmod +x ./app/artifact/explore-cli-linux-arm64 && ./app/artifact/explore-cli-linux-arm64 --version'
+      - name: test debian ${{ matrix.arch }} package
+        if: ${{ matrix.debian == true && matrix.arch == 'amd64' }}
+        run: docker run --platform=linux/${{ matrix.arch }} --rm -v $(pwd):/app debian /bin/bash -c 'apt update && apt install -y libicu-dev && chmod +x ./app/artifact/explore-cli-linux-x64 && ./app/artifact/explore-cli-linux-x64 --version'
+      - name: test 'macos-14-arm'
+        if: ${{ matrix.os == 'macos-14' && matrix.arch == 'arm64' }}
+        run: chmod +x artifact/explore-cli-osx-arm64 && artifact/explore-cli-osx-arm64 --version
+      - name: test 'macos-14-amd'
+        if: ${{ matrix.os == 'macos-14' && matrix.arch == 'amd64' }}
+        run: chmod +x artifact/explore-cli-osx-x64 && artifact/explore-cli-osx-x64 --version
+      - name: test 'windows-latest'
+        if: ${{ matrix.os == 'windows-latest' }}
+        run: artifact/explore-cli-win-x64.exe --version
+      - name: test 'ubuntu-latest'
+        if: ${{ matrix.os == 'ubuntu-latest' && matrix.docker != true }}
+        run: chmod +x artifact/explore-cli-linux-x64 && artifact/explore-cli-linux-x64 --version
+
+    publish:
+      runs-on: ubuntu-latest
+      if: github.event_name == 'workflow_dispatch'
+      # if: |
+      #   startsWith(github.ref, 'refs/tags/v')
+      needs: [build,test]
+
+      steps:
+        - name: Install GitVersion
+          uses: gittools/actions/gitversion/setup@v0.10.2
+          with:
+            versionSpec: '5.x'
+        - name: checkout
+          uses: actions/checkout@v4
+          with:
+            fetch-depth: 0
+        - name: Determine Version
+          id: gitVersion
+          uses: gittools/actions/gitversion/execute@v0.10.2
+          with:
+            useConfigFile: true
+            configFilePath: ./.github/gitversion.yml
+        - name: Download artifacts
+          uses: actions/download-artifact@v4
+
+        - name: Upload Release Assets
+          uses: svenstaro/upload-release-action@v2
+          with:
+            repo_token: ${{ secrets.GITHUB_TOKEN }}
+            file: artifact/*
+            file_glob: true
+            tag: ${{ steps.gitversion.outputs.MajorMinorPatch }}

--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install GitVersion
         uses: gittools/actions/gitversion/setup@v0.10.2
         with:
-          versionSpec: '5.x'          
+          versionSpec: '5.x'
           
       # check out code
       - name: 'Checkout code'

--- a/.gitignore
+++ b/.gitignore
@@ -396,3 +396,6 @@ FodyWeavers.xsd
 
 # JetBrains Rider
 *.sln.iml
+
+# distribution artifacts
+/dist

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,64 @@
+all: build
+SHELL:=/bin/bash
+APP_NAME = "explore-cli"
+.PHONY: dist
+
+RIDS = "linux-x64" "linux-arm64" "linux-musl-x64" "linux-musl-arm64" "osx-x64" "osx-arm64" "win-x64" "win-arm64"
+
+build: clean
+	for rid in $(RIDS); do \
+		echo "Building for $$rid..."; \
+		dotnet publish -c Release -p:PublishSingleFile=true -p:SelfContained=true -p:PublishReadyToRun=true -p:PublishTrimmed=true -p:StaticLink=true -r $$rid -o bin/$(APP_NAME)-$$rid; \
+	done || true
+
+# the above true condition is a yak shave, 
+# /usr/local/share/dotnet/sdk/7.0.409/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.Publish.targets(111,5): 
+# error NETSDK1098: Applications published to a single-file are required to use the application host. 
+# You must either set PublishSingleFile to false or set UseAppHost to true.
+
+debug: clean
+	@echo "Building in debug mode..."
+	for rid in $(RIDS); do \
+		echo "Building for $$rid..."; \
+		dotnet publish -c Debug -p:PublishSingleFile=true -p:SelfContained=true -p:PublishReadyToRun=true-r $$rid -o bin/$(APP_NAME)-$$rid; \
+	done
+
+size:
+	@echo "Size of the binaries:"
+	for rid in $(RIDS); do \
+		echo "Size of bin/$(APP_NAME)-$$rid:"; \
+		ls -lh bin/$(APP_NAME)-$$rid/; \
+	done
+
+file:
+	@echo "File type of the binaries:"
+	for rid in $(RIDS); do \
+		echo "File type of bin/$(APP_NAME)-$$rid:"; \
+		file bin/$(APP_NAME)-$$rid/*; \
+	done
+
+dist:
+	rm -rf dist
+	mkdir -p dist
+	for rid in $(RIDS); do \
+		rm -f bin/$(APP_NAME)-$$rid/*.pdb; \
+		cd bin/$(APP_NAME)-$$rid; \
+		if [[ "$$rid" == *"win"* ]]; then \
+			gzip --stdout --best *.Cli* > $(APP_NAME)-$$rid.exe.gz; \
+			shasum -a 256 $(APP_NAME)-$$rid.exe.gz > $(APP_NAME)-$$rid.exe.gz.256; \
+			mv $(APP_NAME)-$$rid.exe.gz ../../dist;\
+			mv $(APP_NAME)-$$rid.exe.gz.256 ../../dist;\
+		else \
+			gzip --stdout --best *.Cli* > $(APP_NAME)-$$rid.gz; \
+			shasum -a 256 $(APP_NAME)-$$rid.gz > $(APP_NAME)-$$rid.gz.256; \
+			mv $(APP_NAME)-$$rid.gz ../../dist;\
+			mv $(APP_NAME)-$$rid.gz.256 ../../dist;\
+		fi; \
+		cd ../../; \
+	done
+
+clean:
+	@echo "Cleaning..."
+	@rm -rf bin
+	@rm -rf obj
+	@rm -rf dist

--- a/README.md
+++ b/README.md
@@ -36,9 +36,41 @@ You will need the following:
 
 ### Install the CLI
 
+#### Nuget
+
 Download and install the CLI tool from Nuget: https://www.nuget.org/packages/Explore.Cli
 
 `dotnet tool install --global Explore.Cli`
+
+#### GitHub Releases
+
+Standalone releases of the Explore.CLI tool are published to GitHub Releases.
+
+##### Supported Platforms
+
+| OS      | Architecture | Supported  |
+| ------- | ------------ | ---------  |
+| OSX     | x86_64       | ✅         |
+| Linux   | x86_64       | ✅         |
+| Windows | x86_64       | ✅         |
+| OSX     | arm64        | ✅         |
+| Linux   | arm64        | ✅         |
+| Windows | arm64        | ✅         |
+| Alpine  | x86_64       | ✅         |
+| Alpine  | arm64        | ✅         | 
+
+###### Pre-requisites
+
+- `libicu` - Linux musl and glibc based systems
+- `gcc` - Linux musl based systems
+
+###### Alpine
+
+`apk add -y gcc icu`
+
+###### Debian
+
+`apt update && apt install -y libicu`
 
 ### Session Cookies for CLI command
 

--- a/src/Explore.Cli/Explore.Cli.csproj
+++ b/src/Explore.Cli/Explore.Cli.csproj
@@ -30,6 +30,8 @@
     <PackageReference Include="NJsonSchema" Version="10.9.0" />
     <PackageReference Include="Spectre.Console" Version="0.47.0" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
+    <PackageReference Include="System.Text.Encoding.Extensions" Version="4.3.0" />
+    <PackageReference Include="System.IO.FileSystem.Primitives" Version="4.3.0" />
     <None Include="..\..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
fixes #24 

## Yak Shave

Oddly the publish command fails, but the apps work fine. Setting `UseAppHost` to true results in more files than we need and unnecessarily binds the executable to `Explore.Cli.Dll` which we don't want.

```
the above true condition is a yak shave, 
/usr/local/share/dotnet/sdk/7.0.409/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.Publish.targets(111,5): 
error NETSDK1098: Applications published to a single-file are required to use the application host. 
You must either set PublishSingleFile to false or set UseAppHost to true.
```

I think it is this bug

https://github.com/dotnet/runtime/discussions/79948

We are mitigating the fact that the job can pass with an app that has actually failed to build, by testing each of the output executables on end user machines (with exception to win-arm64 as we have no CI capabilities afforded by GH), which if these fail, will block the release

## Linux

Caveats for linux users.

(can be mitigated by move to .NET 8 - [ref to static linking](https://github.com/dotnet/runtime/blob/main/src/coreclr/nativeaot/docs/compiling.md#using-statically-linked-icu))

Requirements

  - `libicu` - `musl` and `glibc` based systems
  - `musl` based systems `gcc`

### Alpine
  
  `apk add gcc icu`

### Debian 

  `apt update && apt install -y libicu`
  
 ## MacOS

Dynamically linked to only system libraries

### X64

```sh
bin/hello_dotnet-osx-x64/Explore.Cli:
        /usr/lib/libz.1.dylib (compatibility version 1.0.0, current version 1.2.11)
        /usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1311.0.0)
        /System/Library/Frameworks/GSS.framework/Versions/A/GSS (compatibility version 1.0.0, current version 1.0.0)
        /System/Library/Frameworks/Foundation.framework/Versions/C/Foundation (compatibility version 300.0.0, current version 1856.105.0)
        /System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation (compatibility version 150.0.0, current version 1856.105.0)
        /System/Library/Frameworks/Security.framework/Versions/A/Security (compatibility version 1.0.0, current version 60157.60.19)
        /System/Library/Frameworks/CoreServices.framework/Versions/A/CoreServices (compatibility version 1.0.0, current version 1141.1.0)
        /usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 1200.3.0)
        /usr/lib/libobjc.A.dylib (compatibility version 1.0.0, current version 228.0.0)
```

### ARM64


```sh
bin/hello_dotnet-osx-arm64/Explore.Cli:
        /usr/lib/libz.1.dylib (compatibility version 1.0.0, current version 1.2.11)
        /usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1311.0.0)
        /System/Library/Frameworks/GSS.framework/Versions/A/GSS (compatibility version 1.0.0, current version 1.0.0)
        /System/Library/Frameworks/Foundation.framework/Versions/C/Foundation (compatibility version 300.0.0, current version 1856.105.0)
        /System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation (compatibility version 150.0.0, current version 1856.105.0)
        /System/Library/Frameworks/Security.framework/Versions/A/Security (compatibility version 1.0.0, current version 60157.60.19)
        /System/Library/Frameworks/CoreServices.framework/Versions/A/CoreServices (compatibility version 1.0.0, current version 1141.1.0)
        /usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 1200.3.0)
        /usr/lib/libobjc.A.dylib (compatibility version 1.0.0, current version 228.0.0)
```


## Windows

### X64

Tested on MacOS M1 with Parallels Windows Instance

### ARM64

Tested on MacOS M1 with Parallels Windows Instance
