### PR TITLE
fix: drop PublishTrimmed from binary dist

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,0 +1,17 @@
+FROM alpine
+RUN apk --no-cache add curl gcc icu
+
+RUN if [ "$(uname -m)" = "aarch64" ]; then \
+        export BINARY_ARCH=arm64; \
+    elif [ "$(uname -m)" = "x86_64" ]; then  \
+        export BINARY_ARCH=x64; \
+    else \
+        echo unsupported arch "$(uname -m)"; \
+        exit 1; \
+    fi && \
+    curl -LO https://github.com/YOU54F/explore-cli/releases/download/0.6.0/explore-cli-linux-musl-$BINARY_ARCH.gz && \
+    gunzip explore-cli-linux-musl-$BINARY_ARCH.gz && \
+    chmod +x explore-cli-linux-musl-$BINARY_ARCH && \
+    mv explore-cli-linux-musl-$BINARY_ARCH /usr/local/bin/explore-cli && \
+    rm -rf explore-cli-linux-musl-$BINARY_ARCH.gz
+ENTRYPOINT [ "explore-cli" ]

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -9,7 +9,7 @@ RUN if [ "$(uname -m)" = "aarch64" ]; then \
         echo unsupported arch "$(uname -m)"; \
         exit 1; \
     fi && \
-    curl -LO https://github.com/YOU54F/explore-cli/releases/download/0.6.0/explore-cli-linux-musl-$BINARY_ARCH.gz && \
+    curl -LO https://github.com/smartbear-devrel/explore-cli/releases/download/0.6.0/explore-cli-linux-musl-$BINARY_ARCH.gz && \
     gunzip explore-cli-linux-musl-$BINARY_ARCH.gz && \
     chmod +x explore-cli-linux-musl-$BINARY_ARCH && \
     mv explore-cli-linux-musl-$BINARY_ARCH /usr/local/bin/explore-cli && \

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -9,7 +9,7 @@ RUN if [ "$(uname -m)" = "aarch64" ]; then \
         echo unsupported arch "$(uname -m)"; \
         exit 1; \
     fi && \
-    curl -LO https://github.com/YOU54F/explore-cli/releases/download/0.6.0/explore-cli-linux-$BINARY_ARCH.gz && \
+    curl -LO https://github.com/smartbear-devrel/explore-cli/releases/download/0.6.0/explore-cli-linux-$BINARY_ARCH.gz && \
     gunzip explore-cli-linux-$BINARY_ARCH.gz && \
     chmod +x explore-cli-linux-$BINARY_ARCH && \
     mv explore-cli-linux-$BINARY_ARCH /usr/local/bin/explore-cli && \

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -1,5 +1,5 @@
 FROM debian:12-slim
-RUN apt update && apt install -y libicu-dev
+RUN apt update && apt install -y curl libicu-dev
 
 RUN if [ "$(uname -m)" = "aarch64" ]; then \
         export BINARY_ARCH=arm64; \

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -1,0 +1,17 @@
+FROM debian:12-slim
+RUN apt update && apt install -y libicu-dev
+
+RUN if [ "$(uname -m)" = "aarch64" ]; then \
+        export BINARY_ARCH=arm64; \
+    elif [ "$(uname -m)" = "x86_64" ]; then  \
+        export BINARY_ARCH=x64; \
+    else \
+        echo unsupported arch "$(uname -m)"; \
+        exit 1; \
+    fi && \
+    curl -LO https://github.com/YOU54F/explore-cli/releases/download/0.6.0/explore-cli-linux-$BINARY_ARCH.gz && \
+    gunzip explore-cli-linux-$BINARY_ARCH.gz && \
+    chmod +x explore-cli-linux-$BINARY_ARCH && \
+    mv explore-cli-linux-$BINARY_ARCH /usr/local/bin/explore-cli && \
+    rm -rf explore-cli-linux-$BINARY_ARCH.gz
+ENTRYPOINT [ "explore-cli" ]

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ RIDS = "linux-x64" "linux-arm64" "linux-musl-x64" "linux-musl-arm64" "osx-x64" "
 build: clean
 	for rid in $(RIDS); do \
 		echo "Building for $$rid..."; \
-		dotnet publish -c Release -p:PublishSingleFile=true -p:SelfContained=true -p:PublishReadyToRun=true -p:PublishTrimmed=true -p:StaticLink=true -r $$rid -o bin/$(APP_NAME)-$$rid; \
+		dotnet publish -c Release -p:PublishSingleFile=true -p:SelfContained=true -p:PublishReadyToRun=true -p:StaticLink=true -r $$rid -o bin/$(APP_NAME)-$$rid; \
 	done || true
 
 # the above true condition is a yak shave, 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,53 @@ Standalone releases of the Explore.CLI tool are published to GitHub Releases.
 
 `apt update && apt install -y libicu-dev`
 
+#### Docker
+
+Dockerfiles are provided for amd64 & arm64 flavours
+
+- Alpine
+  - `./Dockerfile.alpine`
+- Debian
+  - `./Dockerfile.debian`
+
+##### Building images
+
+```sh
+docker build . --platform=linux/arm64 -f Dockerfile.debian  -t explore-cli:debian-arm64
+docker build . --platform=linux/arm64 -f Dockerfile.debian  -t explore-cli:debian-amd64
+docker build . --platform=linux/arm64 -f Dockerfile.alpine  -t explore-cli:alpine-arm64
+docker build . --platform=linux/arm64 -f Dockerfile.alpine  -t explore-cli:alpine-amd64
+```
+
+##### Using images
+
+The `entrypoint` is the `explore-cli` application.
+
+Set environment variables in your shell
+
+```sh
+export EXPLORE_SESSION_TOKEN=<SESSION_TOKEN>
+export EXPLORE_XSRF_TOKEN=<XSRF-TOKEN>
+```
+
+Run your created docker image, with your required explore-cli command.
+
+In our example we are using `import-spaces` which we have in our local directory under the `spaces` folder.
+
+The `spaces` folder is volume mounted into our container in `/spaces`, and commands to file paths should 
+reference this folder.
+
+```sh
+docker run --platform=linux/amd64 \
+  --rm \
+  -it \
+  -v $PWD/spaces:/spaces \
+  explore-cli:debian \
+  import-spaces \
+  --explore-cookie "SESSION=${EXPLORE_SESSION_TOKEN}; XSRF-TOKEN=${EXPLORE_XSRF_TOKEN}" \
+  -fp /spaces/explore_demo_spaces.json
+```
+
 ### Session Cookies for CLI command
 
 You will need to obtain certain cookies from an active session in SwaggerHub Explore to invoke the `CLI` commands.

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Standalone releases of the Explore.CLI tool are published to GitHub Releases.
 
 ###### Debian
 
-`apt update && apt install -y libicu`
+`apt update && apt install -y libicu-dev`
 
 ### Session Cookies for CLI command
 


### PR DESCRIPTION
When creating our binaries with PublishTrimmed=True, we get the following warning when building.

```
Using member 'System.Text.Json.JsonSerializer.Deserialize<TValue>(String, JsonSerializerOptions)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.
```

This results in an error at execution time

```
processing ...
An error occurred: Method 'get_ReferencePath' in type 'NJsonSchema.JsonSchema' from assembly 'NJsonSchema, Version=10.9.0.0, Culture=neutral, PublicKeyToken=c2f9c3bdfae56102' does not have an implementation.
```

or 

```
Unhandled exception: System.NotSupportedException: Deserialization of types without a parameterless constructor, a singular parameterized constructor, or a parameterized constructor annotated with 'JsonConstructorAttribute' is not supported. Type 'Explore.Cli.Models.PagedSpaces'. Path: $ | LineNumber: 0 | BytePositionInLine: 1.
 ---> System.NotSupportedException: Deserialization of types without a parameterless constructor, a singular parameterized constructor, or a parameterized constructor annotated with 'JsonConstructorAttribute' is not supported. Type 'Explore.Cli.Models.PagedSpaces'.
   --- End of inner exception stack trace ---
   at System.Text.Json.ThrowHelper.ThrowNotSupportedException(ReadStack& , Utf8JsonRead
```

Depending on the command.

The resolution appears to be setting PublishTrimmed to False

Related issue:- https://github.com/dotnet/runtime/issues/93714



