### PR TITLE
Improve support for nested postman collection items

### DIFF
--- a/.github/gitversion.yml
+++ b/.github/gitversion.yml
@@ -1,4 +1,4 @@
-next-version: 0.7.0
+next-version: 0.8.0
 assembly-versioning-scheme: MajorMinorPatch
 assembly-file-versioning-scheme: MajorMinorPatchTag
 assembly-informational-format: '{InformationalVersion}'

--- a/README.md
+++ b/README.md
@@ -257,7 +257,8 @@ From SwaggerHub Explore, navigate to your browser development tools, locate the 
 
 > **Notes:**
 > - Compatible with Postman Collections v2.1
-> - Nested collections get flattened into a single Explore space
+> - Root level request get bundled into API folder with same name as collection
+> - Nested collections get added to an API folder with naming format (`parent folder - nested folder`)
 > - GraphQL collections/requests not supported
 > - Environments, Authorization data (not including explicit headers), Pre-request Scripts, Tests are not included in import
 
@@ -297,7 +298,6 @@ From SwaggerHub Explore, navigate to your browser development tools, locate the 
 > - gRPC collections/requests are not supported
 > - Environments variables are inlined and set within the Explore Space
 > - Authorization - only Basic and Bearer Token variants are supported
-
 
 ### Running the `import-pact-file` command
 

--- a/src/Explore.Cli/Explore.Cli.csproj
+++ b/src/Explore.Cli/Explore.Cli.csproj
@@ -27,7 +27,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.2.0" />
-    <PackageReference Include="NJsonSchema" Version="10.9.0" />
+    <PackageReference Include="NJsonSchema" Version="11.1.0" />
     <PackageReference Include="Spectre.Console" Version="0.47.0" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <PackageReference Include="System.Text.Encoding.Extensions" Version="4.3.0" />

--- a/src/Explore.Cli/Models/ExploreCliModels.cs
+++ b/src/Explore.Cli/Models/ExploreCliModels.cs
@@ -1,6 +1,15 @@
+using Explore.Cli.Models.Explore;
+
 namespace Explore.Cli.Models;
+
 
 public partial class SchemaValidationResult {
     public bool isValid { get; set; } = false;
     public string? Message { get; set; }
+}
+
+public partial class StagedAPI {
+    public string APIName { get; set; } = string.Empty;
+    public string APIUrl { get; set; } = string.Empty;
+    public List<Connection> Connections { get; set; } = new List<Connection>();
 }

--- a/test/Explore.Cli.Tests/PostmanCollectionMappingHelperTests.cs
+++ b/test/Explore.Cli.Tests/PostmanCollectionMappingHelperTests.cs
@@ -1,5 +1,6 @@
 using Explore.Cli.Models.Explore;
 using Explore.Cli.Models.Postman;
+using Explore.Cli.Models;
 using System.Text.Json;
 
 public class PostmanCollectionMappingHelperTests
@@ -120,5 +121,45 @@ public class PostmanCollectionMappingHelperTests
         Assert.Equal("Get authenticated user", postmanCollection?.Item?[0].ItemList?[0].Name);
         Assert.Equal("GET", postmanCollection?.Item?[0].ItemList?[0].Request?.Method?.ToString());
         Assert.Equal("Gets information about the authenticated user.", postmanCollection?.Item?[0].ItemList?[0].Request?.Description?.Content?.ToString());
+    }
+
+    [Fact]
+    public void ProcessNestedCollections_ShouldReturnTwoStagedAPIs()
+    {
+        // Arrange
+        var filePath = "../../../fixtures/API_.Payees_API.postman_collection.json";
+        var mockCollectionAsJson = File.ReadAllText(filePath);
+        var postmanCollection = JsonSerializer.Deserialize<PostmanCollection>(mockCollectionAsJson);
+
+        // Act
+        List<StagedAPI> result = new List<StagedAPI>();
+        if (postmanCollection != null)
+        {
+            result = PostmanCollectionMappingHelper.MapPostmanCollectionToStagedAPI(postmanCollection, "Payees API");
+        }
+        // Assert
+        Assert.NotNull(result);
+        Assert.IsType<List<StagedAPI>>(result);
+        Assert.Equal(2, result.Count);
+    }
+
+    [Fact]
+    public void ProcessNestedCollections_ShouldReturnMultipleStagedAPIs()
+    {
+        // Arrange
+        var filePath = "../../../fixtures/API.Payees_API_mixed_urls.postman_collection.json";
+        var mockCollectionAsJson = File.ReadAllText(filePath);
+        var postmanCollection = JsonSerializer.Deserialize<PostmanCollection>(mockCollectionAsJson);
+
+        // Act
+        List<StagedAPI> result = new List<StagedAPI>();
+        if (postmanCollection != null)
+        {
+            result = PostmanCollectionMappingHelper.MapPostmanCollectionToStagedAPI(postmanCollection, "Payees API");
+        }
+        // Assert
+        Assert.NotNull(result);
+        Assert.IsType<List<StagedAPI>>(result);
+        Assert.Equal(2, result.Count);
     }
 }

--- a/test/Explore.Cli.Tests/fixtures/API.Payees_API_mixed_urls.postman_collection.json
+++ b/test/Explore.Cli.Tests/fixtures/API.Payees_API_mixed_urls.postman_collection.json
@@ -1,0 +1,235 @@
+{
+	"info": {
+		"_postman_id": "ad365ee6-44ef-4ce1-84e8-86894f4713ff",
+		"name": "Payees API",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "304136"
+	},
+	"item": [
+		{
+			"name": "Irish Payees",
+			"item": [
+				{
+					"name": "GET Irish LTD companies",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {\r",
+									"    pm.response.to.have.status(200);\r",
+									"});\r",
+									"\r",
+									"pm.test(\"Response time is less than 1000ms\", function () {\r",
+									"    pm.expect(pm.response.responseTime).to.be.below(1000);\r",
+									"});\r",
+									"\r",
+									"pm.test(\"Your test name\", function () {\r",
+									"    var jsonData = pm.response.json();\r",
+									"    pm.expect(jsonData.data[0].bank_account_currency).to.eql(\"EUR\");\r",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "oauth2",
+							"oauth2": [
+								{
+									"key": "addTokenTo",
+									"value": "header",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "https://sbdevrel-fua-smartbearcoin-prd.azurewebsites.net/api/payees?country_of_registration=IE&name=ltd",
+							"protocol": "https",
+							"host": [
+								"sbdevrel-fua-smartbearcoin-prd",
+								"azurewebsites",
+								"net"
+							],
+							"path": [
+								"api",
+								"payees"
+							],
+							"query": [
+								{
+									"key": "country_of_registration",
+									"value": "IE"
+								},
+								{
+									"key": "name",
+									"value": "ltd"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "GET Payee Details",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {\r",
+									"    pm.response.to.have.status(200);\r",
+									"});\r",
+									"\r",
+									"pm.test(\"Response time is less than 1000ms\", function () {\r",
+									"    pm.expect(pm.response.responseTime).to.be.below(1000);\r",
+									"});\r",
+									"\r",
+									"pm.test(\"Your test name\", function () {\r",
+									"    var jsonData = pm.response.json();\r",
+									"    pm.expect(jsonData.data[0].bank_account_currency).to.eql(\"EUR\");\r",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "oauth2",
+							"oauth2": [
+								{
+									"key": "addTokenTo",
+									"value": "header",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "https://sbdevrel-fua-smartbearcoin-prd.azurewebsites.net/api/payees/4eb603f3-e7e7-47b1-a5df-557b6204616e",
+							"protocol": "https",
+							"host": [
+								"sbdevrel-fua-smartbearcoin-prd",
+								"azurewebsites",
+								"net"
+							],
+							"path": [
+								"api",
+								"payees",
+								"4eb603f3-e7e7-47b1-a5df-557b6204616e"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "GET DE companies",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Status code is 200\", function () {\r",
+							"    pm.response.to.have.status(200);\r",
+							"});\r",
+							"\r",
+							"pm.test(\"Response time is less than 1000ms\", function () {\r",
+							"    pm.expect(pm.response.responseTime).to.be.below(1000);\r",
+							"});\r",
+							"\r",
+							"pm.test(\"Your test name\", function () {\r",
+							"    var jsonData = pm.response.json();\r",
+							"    pm.expect(jsonData.data[0].bank_account_currency).to.eql(\"EUR\");\r",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"auth": {
+					"type": "oauth2",
+					"oauth2": [
+						{
+							"key": "addTokenTo",
+							"value": "header",
+							"type": "string"
+						}
+					]
+				},
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "https://sbdevrel-fua-smartbearcoin-prd.azurewebsites.net/api/payees?country_of_registration=IE&name=ltd",
+					"protocol": "https",
+					"host": [
+						"sbdevrel-fua-smartbearcoin-prd",
+						"azurewebsites",
+						"net"
+					],
+					"path": [
+						"api",
+						"payees"
+					],
+					"query": [
+						{
+							"key": "country_of_registration",
+							"value": "IE"
+						},
+						{
+							"key": "name",
+							"value": "ltd"
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "http://www.dneonline.com/calculator.asmx",
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "SOAPAction",
+						"value": "http://tempuri.org/Add",
+						"type": "text"
+					},
+					{
+						"key": "Content-Type",
+						"value": "text/xml",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "<soap:Envelope\r\n    xmlns:soap=\"http://www.w3.org/2003/05/soap-envelope\"\r\n    xmlns:tem=\"http://tempuri.org/\">\r\n    <soap:Header/>\r\n    <soap:Body>\r\n        <tem:Add>\r\n            <tem:intA>10</tem:intA>\r\n            <tem:intB>10</tem:intB>\r\n        </tem:Add>\r\n    </soap:Body>\r\n</soap:Envelope>",
+					"options": {
+						"raw": {
+							"language": "xml"
+						}
+					}
+				},
+				"url": {
+					"raw": "http://www.dneonline.com/calculator.asmx",
+					"protocol": "http",
+					"host": [
+						"www",
+						"dneonline",
+						"com"
+					],
+					"path": [
+						"calculator.asmx"
+					]
+				}
+			},
+			"response": []
+		}
+	]
+}

--- a/test/Explore.Cli.Tests/fixtures/API_.Payees_API.postman_collection.json
+++ b/test/Explore.Cli.Tests/fixtures/API_.Payees_API.postman_collection.json
@@ -1,0 +1,195 @@
+{
+	"info": {
+		"_postman_id": "ad365ee6-44ef-4ce1-84e8-86894f4713ff",
+		"name": "Payees API",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "304136"
+	},
+	"item": [
+		{
+			"name": "Irish Payees",
+			"item": [
+				{
+					"name": "GET Irish LTD companies",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {\r",
+									"    pm.response.to.have.status(200);\r",
+									"});\r",
+									"\r",
+									"pm.test(\"Response time is less than 1000ms\", function () {\r",
+									"    pm.expect(pm.response.responseTime).to.be.below(1000);\r",
+									"});\r",
+									"\r",
+									"pm.test(\"Your test name\", function () {\r",
+									"    var jsonData = pm.response.json();\r",
+									"    pm.expect(jsonData.data[0].bank_account_currency).to.eql(\"EUR\");\r",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "oauth2",
+							"oauth2": [
+								{
+									"key": "addTokenTo",
+									"value": "header",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "https://sbdevrel-fua-smartbearcoin-prd.azurewebsites.net/api/payees?country_of_registration=IE&name=ltd",
+							"protocol": "https",
+							"host": [
+								"sbdevrel-fua-smartbearcoin-prd",
+								"azurewebsites",
+								"net"
+							],
+							"path": [
+								"api",
+								"payees"
+							],
+							"query": [
+								{
+									"key": "country_of_registration",
+									"value": "IE"
+								},
+								{
+									"key": "name",
+									"value": "ltd"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "GET Payee Details",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {\r",
+									"    pm.response.to.have.status(200);\r",
+									"});\r",
+									"\r",
+									"pm.test(\"Response time is less than 1000ms\", function () {\r",
+									"    pm.expect(pm.response.responseTime).to.be.below(1000);\r",
+									"});\r",
+									"\r",
+									"pm.test(\"Your test name\", function () {\r",
+									"    var jsonData = pm.response.json();\r",
+									"    pm.expect(jsonData.data[0].bank_account_currency).to.eql(\"EUR\");\r",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "oauth2",
+							"oauth2": [
+								{
+									"key": "addTokenTo",
+									"value": "header",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "https://sbdevrel-fua-smartbearcoin-prd.azurewebsites.net/api/payees/4eb603f3-e7e7-47b1-a5df-557b6204616e",
+							"protocol": "https",
+							"host": [
+								"sbdevrel-fua-smartbearcoin-prd",
+								"azurewebsites",
+								"net"
+							],
+							"path": [
+								"api",
+								"payees",
+								"4eb603f3-e7e7-47b1-a5df-557b6204616e"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "GET DE companies",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Status code is 200\", function () {\r",
+							"    pm.response.to.have.status(200);\r",
+							"});\r",
+							"\r",
+							"pm.test(\"Response time is less than 1000ms\", function () {\r",
+							"    pm.expect(pm.response.responseTime).to.be.below(1000);\r",
+							"});\r",
+							"\r",
+							"pm.test(\"Your test name\", function () {\r",
+							"    var jsonData = pm.response.json();\r",
+							"    pm.expect(jsonData.data[0].bank_account_currency).to.eql(\"EUR\");\r",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"auth": {
+					"type": "oauth2",
+					"oauth2": [
+						{
+							"key": "addTokenTo",
+							"value": "header",
+							"type": "string"
+						}
+					]
+				},
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "https://sbdevrel-fua-smartbearcoin-prd.azurewebsites.net/api/payees?country_of_registration=IE&name=ltd",
+					"protocol": "https",
+					"host": [
+						"sbdevrel-fua-smartbearcoin-prd",
+						"azurewebsites",
+						"net"
+					],
+					"path": [
+						"api",
+						"payees"
+					],
+					"query": [
+						{
+							"key": "country_of_registration",
+							"value": "IE"
+						},
+						{
+							"key": "name",
+							"value": "ltd"
+						}
+					]
+				}
+			},
+			"response": []
+		}
+	]
+}


### PR DESCRIPTION
Add support for better management of nested folders within Postman Collections.

Root level requests are now added to an Explore API folder with same name as Explore Space (e.g. Postman collection 'foo' with requests will create Explore Space 'foo' with API folder 'foo' which will contain the request connections).

Nested folders within a collection, will have a name format of `Parent - Child` (e.g. foo/bar will create API folder called `foo - bar`, foo/bar/baz will create API folder called `foo - bar - baz`)

Fixes: #36