### PR TITLE
ci: add mono as removed from base gh image

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -68,6 +68,9 @@ jobs:
       - name: Setup NuGet
         uses: NuGet/setup-nuget@v1.0.5
 
+      - name: setup mono
+        run: brew install mono
+
       - name: Publish to Nuget
         run: nuget push **\*.nupkg -Source 'https://api.nuget.org/v3/index.json' -ApiKey $NUGET_API_KEY
         working-directory: src/Explore.Cli


### PR DESCRIPTION
mono seems to be used during our nuget publish step

not tested yet as wf step only actioned on wf dispatch from main branch