### PR TITLE
ci: add mono via apt

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -70,8 +70,15 @@ jobs:
 
       - name: setup mono
         run: |
-          eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
-          brew install mono
+          sudo apt install dirmngr ca-certificates gnupg
+          sudo gpg --homedir /tmp --no-default-keyring --keyring \
+            /usr/share/keyrings/mono-official-archive-keyring.gpg \
+            --keyserver hkp://keyserver.ubuntu.com:80 \ 
+            --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF \
+             echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.gpg] https://download.mono-project.com/repo/debian stable-buster main" | sudo tee /etc/apt/sources.list.d/mono-official-stable.list
+           sudo apt update
+           sudo apt install -y mono-complete
+          
 
       - name: Publish to Nuget
         run: nuget push **\*.nupkg -Source 'https://api.nuget.org/v3/index.json' -ApiKey $NUGET_API_KEY


### PR DESCRIPTION
try and try again :)

mono not being added to path via homebrew so just install it via apt instead